### PR TITLE
[codex] Add Nav2 behavior tree demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,13 @@ RUN apt-get update -q && \
     rm -rf /var/lib/apt/lists/*
 
 # RISE is not packaged in Ubuntu Noble. Keep Notebook from apt so ROS Python
-# packages remain on the system interpreter, and install only the extension.
-RUN python3 -m pip install --break-system-packages --no-cache-dir RISE
+# packages remain on the system interpreter, and install only frontend assets
+# that the Ubuntu widget packages do not reliably expose to classic Notebook.
+RUN python3 -m pip install --break-system-packages --no-cache-dir \
+      RISE \
+      jupyterlab_widgets==3.0.9 && \
+    python3 -m pip install --break-system-packages --no-cache-dir --ignore-installed \
+      widgetsnbextension==4.0.9
 
 RUN mkdir -p /home/ubuntu/turtlebot3_ws/src /home/ubuntu/.jupyter && \
     chown -R ubuntu:ubuntu /home/ubuntu/turtlebot3_ws /home/ubuntu/.jupyter
@@ -60,6 +65,7 @@ USER root
 
 RUN jupyter-nbextension install rise --py --sys-prefix && \
     jupyter nbextension enable rise --py --sys-prefix && \
-    jupyter nbextension enable --py widgetsnbextension
+    jupyter nbextension install --py widgetsnbextension --sys-prefix && \
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 USER root

--- a/jupyter_notebooks/exercises/11. Behavior Trees with Nav2 Helper Demo.ipynb
+++ b/jupyter_notebooks/exercises/11. Behavior Trees with Nav2 Helper Demo.ipynb
@@ -1,0 +1,279 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "28aeaf12",
+   "metadata": {},
+   "source": "# Demo pomocnicze: Behavior Trees + Nav2\n\nTen notebook łączy dwa wątki z poprzednich ćwiczeń: `py_trees` oraz stos nawigacji Nav2. Robot patroluje okolice zamku w Gazebo zawsze wtedy, gdy nie ma aktywnego celu. Kliknięcie przycisku **Jedź do celu** przełącza drzewo na priorytetowy cel nawigacji. Po dojechaniu do celu żądanie celu jest czyszczone i robot automatycznie wraca do patrolu. **Stop** anuluje aktualne zadanie, publikuje zerowe `/cmd_vel` i zatrzymuje robota.\n\nRdzeń demo jest w pliku `trees_nav.py`. Ten sam plik można uruchomić jako samodzielny test (`python3 trees_nav.py --auto-test`) i jest importowany przez notebook, więc skrypt oraz ćwiczenie używają tej samej implementacji drzewa.\n\nJeśli przyciski `ipywidgets` nie renderują się w przeglądarce, notebook pokazuje też zapasowe przyciski HTML oraz funkcje `go_to_goal()`, `stop_robot()` i `resume_patrol()`, które można uruchomić ręcznie z komórki.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b465913",
+   "metadata": {},
+   "source": [
+    "## Struktura drzewa\n",
+    "\n",
+    "Drzewo jest selektorem priorytetów. W każdym tyknięciu sprawdza gałęzie od góry do dołu i uruchamia pierwszą, której warunek jest spełniony.\n",
+    "\n",
+    "```text\n",
+    "Castle Demo\n",
+    "|- Stopped?        -> Cancel Navigation\n",
+    "|- Goal requested? -> Navigate To Goal\n",
+    "`- No goal?        -> Patrol Castle\n",
+    "```\n",
+    "\n",
+    "Najważniejszy pomysł: patrol jest fallbackiem. Przyciski nie sterują robotem bezpośrednio. Przycisk celu ustawia stan `GOAL`, przycisk stop ustawia `STOPPED`, a brak aktywnego celu oznacza `PATROL`. Dopiero drzewo zachowań wybiera gałąź, a liście drzewa wywołują Nav2 przez `BasicNavigator`.\n",
+    "\n",
+    "Priorytet działa tak:\n",
+    "\n",
+    "- `STOPPED` jest najwyżej, więc zatrzymanie przerywa wszystko inne.\n",
+    "- `GOAL` jest wyżej niż patrol, więc kliknięcie celu przerywa patrol i wysyła nowy cel Nav2.\n",
+    "- `PATROL` jest zachowaniem domyślnym: jeśli nie ma celu do wykonania, robot jedzie po kolejnych punktach wokół zamku.\n",
+    "- Gdy `NavigateToGoal` zakończy się sukcesem, cel jest uznany za wykonany, stan wraca do `PATROL`, a robot kontynuuje patrol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e93a476e",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Uruchom tę komórkę na początku notebooka.\n# Dodaje źródła warsztatu do PYTHONPATH i przygotowuje pomocnicze funkcje terminalowe.\nimport importlib\nimport math\nimport os\nimport shutil\nimport subprocess\nimport sys\nimport threading\nimport time\nimport traceback\nfrom dataclasses import dataclass\nfrom enum import Enum\nfrom pathlib import Path\n\nimport ipywidgets as widgets\nfrom IPython.display import HTML, IFrame, Javascript, SVG, display\n\nROS_DISTRO = os.environ.get(\"ROS_DISTRO\", \"jazzy\")\nWORKSPACE = Path(\"/home/ubuntu/turtlebot3_ws\")\nSOURCE_DIR = WORKSPACE / \"src\" / \"jupyter_notebooks\"\nEXERCISES_DIR = SOURCE_DIR / \"exercises\"\n\nfor path in [SOURCE_DIR, EXERCISES_DIR]:\n    if str(path) not in sys.path:\n        sys.path.insert(0, str(path))\n\n\ndef bash(command, check=True):\n    full = (\n        f\"source /opt/ros/{ROS_DISTRO}/setup.bash; \"\n        f\"source {WORKSPACE}/install/setup.bash 2>/dev/null || true; \"\n        f\"{command}\"\n    )\n    return subprocess.run([\"bash\", \"-lc\", full], text=True, check=check)\n\n\ndef ros_stdout(command, check=False):\n    full = (\n        f\"source /opt/ros/{ROS_DISTRO}/setup.bash; \"\n        f\"source {WORKSPACE}/install/setup.bash 2>/dev/null || true; \"\n        f\"{command}\"\n    )\n    return subprocess.run(\n        [\"bash\", \"-lc\", full],\n        text=True,\n        check=check,\n        stdout=subprocess.PIPE,\n        stderr=subprocess.STDOUT,\n    )\n\n\ndef wait_for_ros_command(command, description, timeout_sec=45, period_sec=1.0):\n    deadline = time.time() + timeout_sec\n    last_output = \"\"\n    while time.time() < deadline:\n        result = ros_stdout(command, check=False)\n        last_output = result.stdout.strip()\n        if result.returncode == 0:\n            print(f\"OK: {description}\")\n            return True\n        time.sleep(period_sec)\n    print(f\"Nie udało się potwierdzić: {description}\")\n    if last_output:\n        print(last_output[-1000:])\n    return False\n\n\ndef print_latest_ros_logs(lines=80):\n    script = (\n        \"latest=$(find ~/.ros/log -maxdepth 2 -name launch.log -type f \"\n        \"-printf '%T@ %p\\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-); \"\n        f\"if [ -n \\\"$latest\\\" ]; then echo \\\"--- $latest ---\\\"; tail -n {int(lines)} \\\"$latest\\\"; fi\"\n    )\n    result = subprocess.run(\n        [\"bash\", \"-lc\", script],\n        text=True,\n        stdout=subprocess.PIPE,\n        stderr=subprocess.STDOUT,\n    )\n    print(result.stdout)\n\n\ndef ensure_ros_environment():\n    if shutil.which(\"ros2\") is None:\n        print(\"Nie widzę komendy ros2. Ten notebook trzeba uruchomić w kontenerze ROS.\")\n        return\n    print(\"ROS_DISTRO:\", ROS_DISTRO)\n    bash(\"ros2 --help | head -n 1\", check=False)\n\n\nensure_ros_environment()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49615833",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import helper_services\n",
+    "from run_in_term import run_lxterminal\n",
+    "\n",
+    "\n",
+    "def terminal(command):\n",
+    "    escaped = command.replace(\"'\", \"'\\\\''\")\n",
+    "    run_lxterminal(\n",
+    "        f\"bash -lc 'source /opt/ros/{ROS_DISTRO}/setup.bash; \"\n",
+    "        f\"source {WORKSPACE}/install/setup.bash 2>/dev/null || true; {escaped}'\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed4972eb",
+   "metadata": {},
+   "source": [
+    "## 1. Uruchom symulację i Nav2\n",
+    "\n",
+    "Pierwsza komórka sprząta stare procesy warsztatowe i uruchamia Gazebo. Kolejne komórki otwierają podgląd VNC, RViz oraz Nav2.\n",
+    "\n",
+    "Ważne: poczekaj na komunikat `Gazebo działa...`, zanim przejdziesz dalej."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8deabd01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "helper_services.cleanup_workshop_processes()\n",
+    "terminal(\"ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py\")\n",
+    "\n",
+    "if not wait_for_ros_command(\"ros2 topic list | grep -qx /clock\", \"Gazebo publikuje /clock\", timeout_sec=45):\n",
+    "    print_latest_ros_logs()\n",
+    "    raise RuntimeError(\n",
+    "        \"Gazebo nie wystartował poprawnie. Nie uruchamiaj jeszcze RViz/Nav2; \"\n",
+    "        \"sprawdź powyższy log. Jeśli widzisz błąd GZ_IP albo std::out_of_range, \"\n",
+    "        \"to problem dotyczy Gazebo Transport w tym kontenerze/hoście, nie drzewa zachowań.\"\n",
+    "    )\n",
+    "\n",
+    "print(\"Gazebo działa i publikuje /clock.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0661d6ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IFrame(\"http://localhost:6080\", width=900, height=520)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93e581b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "terminal(helper_services.turtlebot3_nav2_command())\n",
+    "\n",
+    "amcl_ready = wait_for_ros_command(\n",
+    "    r\"ros2 lifecycle get /amcl 2>/dev/null | grep -qx 'active \\[3\\]'\",\n",
+    "    \"AMCL jest aktywny i gotowy na pozycję początkową\",\n",
+    "    timeout_sec=45,\n",
+    ")\n",
+    "if not amcl_ready:\n",
+    "    print_latest_ros_logs()\n",
+    "    raise RuntimeError(\"AMCL nie wystartował; Nav2 nie może dostać pozycji początkowej.\")\n",
+    "\n",
+    "import rclpy\n",
+    "from rclpy.node import Node\n",
+    "from rclpy.parameter import Parameter\n",
+    "\n",
+    "try:\n",
+    "    rclpy.init()\n",
+    "except RuntimeError:\n",
+    "    pass\n",
+    "\n",
+    "bootstrap_node = Node(\n",
+    "    \"castle_nav2_initial_pose_bootstrap\",\n",
+    "    parameter_overrides=[Parameter(\"use_sim_time\", value=True)],\n",
+    ")\n",
+    "helper_services.publish_initial_pose(bootstrap_node, repeats=25)\n",
+    "bootstrap_node.destroy_node()\n",
+    "\n",
+    "nav2_ready = wait_for_ros_command(\n",
+    "    r\"ros2 lifecycle get /controller_server 2>/dev/null | grep -qx 'active \\[3\\]' && \"\n",
+    "    r\"ros2 lifecycle get /planner_server 2>/dev/null | grep -qx 'active \\[3\\]' && \"\n",
+    "    r\"ros2 lifecycle get /bt_navigator 2>/dev/null | grep -qx 'active \\[3\\]' && \"\n",
+    "    \"ros2 action list | grep -qx /navigate_to_pose\",\n",
+    "    \"Nav2 ma aktywne węzły controller/planner/bt_navigator oraz akcję /navigate_to_pose\",\n",
+    "    timeout_sec=60,\n",
+    ")\n",
+    "if not nav2_ready:\n",
+    "    print_latest_ros_logs()\n",
+    "    raise RuntimeError(\"Nav2 nie wystartował poprawnie. RViz zostanie uruchomiony dopiero po naprawie Nav2.\")\n",
+    "\n",
+    "terminal(helper_services.turtlebot3_rviz_command())\n",
+    "print(\"Nav2 działa; RViz został uruchomiony.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed983195",
+   "metadata": {},
+   "source": [
+    "## 2. Przygotuj węzeł ROS i navigator\n",
+    "\n",
+    "Publikujemy pozycję początkową robota do AMCL, a potem tworzymy `BasicNavigator`, który będzie wywoływany przez liście drzewa.\n",
+    "\n",
+    "`BasicNavigator` jest prostą fasadą na akcje Nav2. W tym ćwiczeniu używamy go do:\n",
+    "\n",
+    "- wysyłania kolejnych punktów patrolu przez `goToPose`,\n",
+    "- anulowania bieżącego celu przez `cancelTask`,\n",
+    "- sprawdzania wyniku przez `isTaskComplete()` i `getResult()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5acbe7d",
+   "metadata": {},
+   "outputs": [],
+   "source": "import trees_nav\n\ntrees_nav = importlib.reload(trees_nav)\nDemoMode = trees_nav.DemoMode\n\n# Domyślne wartości można zmienić w następnej komórce przed inicjalizacją Nav2.\nPATROL_WAYPOINTS = list(trees_nav.PATROL_WAYPOINTS)\nGOAL_X, GOAL_Y, GOAL_YAW = trees_nav.GOAL_POSE\n\nprint(\"Moduł trees_nav załadowany.\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "facd1d90",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Punkty patrolu dookoła zamku. Zmień je, aby pokazać studentom inną trasę.\nPATROL_WAYPOINTS = [\n    (0.45, 1.91, 0.0),\n    (2.53, 0.99, -1.57),\n    (1.72, -1.37, 3.14),\n    (-0.25, -1.15, 1.57),\n]\n\n# Priorytetowy cel po kliknięciu przycisku „Jedź do celu”.\nGOAL_X = 0.50\nGOAL_Y = -1.20\nGOAL_YAW = 0.0\n\ntry:\n    runner.stop(cancel=navigator.cancelTask)\nexcept NameError:\n    pass\nexcept Exception:\n    traceback.print_exc()\n\ndemo_node, demo = trees_nav.setup_navigation(\n    helper_services,\n    waypoints=PATROL_WAYPOINTS,\n    goal=(GOAL_X, GOAL_Y, GOAL_YAW),\n)\nnavigator = demo.navigator\nstate = demo.state\n\nprint(\"Nav2 jest aktywne.\")\nprint(\"Punkty patrolu:\", demo.waypoints)\nprint(\"Cel priorytetowy:\", demo.goal)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "304ca2f5",
+   "metadata": {},
+   "source": "## 3. Drzewo zachowań\n\nLogika drzewa jest w pliku `trees_nav.py`, a notebook importuje ją wprost. Dzięki temu najpierw można przetestować zwykły skrypt Pythona, a potem uruchomić dokładnie ten sam kod z interfejsem Jupyter.\n\nW module są trzy rodzaje elementów:\n\n- warunki (`ModeIs`) tylko sprawdzają stan aplikacji,\n- akcje (`PatrolCastle`, `NavigateToGoal`, `CancelNavigation`) wykonują pracę,\n- liście drzewa nie implementują własnej nawigacji; wywołują Nav2 przez `BasicNavigator`.\n\nPatrol jest fallbackiem: po osiągnięciu celu albo gdy nie ma aktywnego celu, drzewo wraca do patrolu. Lista `PATROL_WAYPOINTS` jest zdefiniowana w module i może być nadpisana w komórce konfiguracyjnej notebooka, więc uruchomienie komórek w poprawnej kolejności nie kończy się błędem `NameError: PATROL_WAYPOINTS is not defined`.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e65801ad",
+   "metadata": {},
+   "outputs": [],
+   "source": "import py_trees\n\nprint(\"Logika drzewa jest w pliku trees_nav.py i jest współdzielona przez notebook oraz test automatyczny.\")\nprint(\"Aktualny stan:\", trees_nav.status_text(state))\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e6a3914",
+   "metadata": {},
+   "outputs": [],
+   "source": "def make_tree():\n    return trees_nav.make_tree(demo)\n\n\nTREE_SVG = \"\"\"\n<svg width=\"760\" height=\"330\" viewBox=\"0 0 760 330\" xmlns=\"http://www.w3.org/2000/svg\">\n  <style>\n    .box { fill: #ffffff; stroke: #334155; stroke-width: 2; rx: 8; }\n    .selector { fill: #e0f2fe; stroke: #0369a1; }\n    .condition { fill: #fef3c7; stroke: #b45309; }\n    .action { fill: #dcfce7; stroke: #15803d; }\n    .txt { font-family: DejaVu Sans, Arial, sans-serif; font-size: 15px; fill: #0f172a; }\n    .small { font-size: 12px; fill: #475569; }\n    .line { stroke: #64748b; stroke-width: 2; fill: none; }\n  </style>\n  <rect class=\"box selector\" x=\"280\" y=\"18\" width=\"200\" height=\"54\"/>\n  <text class=\"txt\" x=\"380\" y=\"42\" text-anchor=\"middle\">Selector</text>\n  <text class=\"small\" x=\"380\" y=\"60\" text-anchor=\"middle\">wybiera pierwszy sukces</text>\n\n  <path class=\"line\" d=\"M380 72 V104\"/>\n  <path class=\"line\" d=\"M135 104 H625\"/>\n  <path class=\"line\" d=\"M135 104 V130 M380 104 V130 M625 104 V130\"/>\n\n  <rect class=\"box condition\" x=\"60\" y=\"130\" width=\"150\" height=\"50\"/>\n  <text class=\"txt\" x=\"135\" y=\"160\" text-anchor=\"middle\">STOPPED?</text>\n  <rect class=\"box action\" x=\"50\" y=\"210\" width=\"170\" height=\"58\"/>\n  <text class=\"txt\" x=\"135\" y=\"235\" text-anchor=\"middle\">Anuluj Nav2</text>\n  <text class=\"small\" x=\"135\" y=\"253\" text-anchor=\"middle\">robot staje</text>\n  <path class=\"line\" d=\"M135 180 V210\"/>\n\n  <rect class=\"box condition\" x=\"305\" y=\"130\" width=\"150\" height=\"50\"/>\n  <text class=\"txt\" x=\"380\" y=\"160\" text-anchor=\"middle\">GOAL?</text>\n  <rect class=\"box action\" x=\"295\" y=\"210\" width=\"170\" height=\"58\"/>\n  <text class=\"txt\" x=\"380\" y=\"235\" text-anchor=\"middle\">Jedź do celu</text>\n  <text class=\"small\" x=\"380\" y=\"253\" text-anchor=\"middle\">po sukcesie czyści cel</text>\n  <path class=\"line\" d=\"M380 180 V210\"/>\n\n  <rect class=\"box condition\" x=\"550\" y=\"130\" width=\"150\" height=\"50\"/>\n  <text class=\"txt\" x=\"625\" y=\"160\" text-anchor=\"middle\">PATROL</text>\n  <rect class=\"box action\" x=\"540\" y=\"210\" width=\"170\" height=\"58\"/>\n  <text class=\"txt\" x=\"625\" y=\"235\" text-anchor=\"middle\">Patrol zamku</text>\n  <text class=\"small\" x=\"625\" y=\"253\" text-anchor=\"middle\">fallback, gdy nie ma celu</text>\n  <path class=\"line\" d=\"M625 180 V210\"/>\n\n  <text class=\"small\" x=\"380\" y=\"315\" text-anchor=\"middle\">Priorytet od lewej do prawej: STOP &gt; GOAL &gt; PATROL fallback</text>\n</svg>\n\"\"\"\n\n\ntree = make_tree()\ntree.setup(timeout=15)\ndisplay(SVG(TREE_SVG))\nprint(py_trees.display.unicode_tree(tree.root))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ace26f",
+   "metadata": {},
+   "source": [
+    "## 4. Sterowanie z notebooka\n",
+    "\n",
+    "Najwygodniejsza wersja używa `ipywidgets`. Jeśli w Twojej przeglądarce zamiast przycisków pojawia się tylko tekstowa reprezentacja widgetu, użyj zapasowych przycisków HTML albo ręcznych funkcji:\n",
+    "\n",
+    "```python\n",
+    "go_to_goal()      # ustawia aktywny cel; cel ma priorytet nad patrolem\n",
+    "stop_robot()      # anuluje Nav2 i zatrzymuje robota\n",
+    "resume_patrol()   # czyści cel i wraca do patrolu\n",
+    "```\n",
+    "\n",
+    "Po dojechaniu do celu `NavigateToGoal` samo ustawia tryb `PATROL`, więc robot nie zostaje w celu na stałe. Patrol jest fallbackiem wtedy, gdy nie ma aktywnego celu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdbb31a8",
+   "metadata": {},
+   "outputs": [],
+   "source": "status = widgets.HTML()\ntree_view = widgets.Output(layout={\"border\": \"1px solid #ddd\", \"max_height\": \"260px\", \"overflow\": \"auto\"})\n\n\ndef status_text():\n    return trees_nav.status_text(state)\n\n\ndef refresh_status():\n    text = status_text()\n    status.value = text.replace(\"|\", \"&nbsp;&nbsp;|&nbsp;&nbsp;\")\n    return text\n\n\ndef go_to_goal():\n    text = demo.request_goal()\n    refresh_status()\n    print(text)\n    return text\n\n\ndef stop_robot():\n    text = demo.request_stop()\n    refresh_status()\n    print(text)\n    return text\n\n\ndef resume_patrol():\n    text = demo.request_patrol()\n    refresh_status()\n    print(text)\n    return text\n\n\ndef request_goal(_):\n    go_to_goal()\n\n\ndef request_stop(_):\n    stop_robot()\n\n\ndef request_patrol(_):\n    resume_patrol()\n\n\n# Zapasowe przyciski HTML działają w klasycznym Jupyter Notebook bez ipywidgets.\nfallback_controls = HTML(\"\"\"\n<div style=\"display:flex;gap:8px;align-items:center;margin:8px 0 12px 0;font-family:sans-serif\">\n  <button style=\"padding:6px 12px;background:#198754;color:white;border:0;border-radius:4px;cursor:pointer\"\n          onclick=\"Jupyter.notebook.kernel.execute('go_to_goal()')\">Jedź do celu</button>\n  <button style=\"padding:6px 12px;background:#dc3545;color:white;border:0;border-radius:4px;cursor:pointer\"\n          onclick=\"Jupyter.notebook.kernel.execute('stop_robot()')\">Stop</button>\n  <button style=\"padding:6px 12px;background:#0dcaf0;color:#111;border:0;border-radius:4px;cursor:pointer\"\n          onclick=\"Jupyter.notebook.kernel.execute('resume_patrol()')\">Wyczyść cel / patrol</button>\n  <span style=\"color:#555\">Jeśli widgety poniżej są tylko tekstem, użyj tych przycisków.</span>\n</div>\n\"\"\")\n\ngo_button = widgets.Button(description=\"Jedź do celu\", button_style=\"success\", icon=\"location-arrow\")\nstop_button = widgets.Button(description=\"Stop\", button_style=\"danger\", icon=\"stop\")\npatrol_button = widgets.Button(description=\"Wyczyść cel / patrol\", button_style=\"info\", icon=\"refresh\")\n\ngo_button.on_click(request_goal)\nstop_button.on_click(request_stop)\npatrol_button.on_click(request_patrol)\nrefresh_status()\n\ndisplay(fallback_controls)\ndisplay(widgets.VBox([widgets.HBox([go_button, stop_button, patrol_button]), status, tree_view]))\nprint(\"Sterowanie gotowe. Jeśli przyciski ipywidgets nie renderują się, użyj przycisków HTML albo funkcji go_to_goal(), stop_robot(), resume_patrol().\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0502a39",
+   "metadata": {},
+   "outputs": [],
+   "source": "def render_tree(tree):\n    refresh_status()\n    with tree_view:\n        tree_view.clear_output(wait=True)\n        print(py_trees.display.unicode_tree(tree.root, show_status=True))\n\n\ntry:\n    runner.stop(cancel=navigator.cancelTask)\nexcept NameError:\n    pass\n\nrunner = trees_nav.TreeRunner(tree, period=0.5, on_tick=render_tree)\nrunner.start()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f84052a",
+   "metadata": {},
+   "source": "## 5. Sprawdzenie ruchu i sprzątanie\n\nOczekiwana sekwencja działania drzewa po uruchomieniu demo:\n\n1. Gdy nie ma aktywnego celu, gałąź `PATROL fallback` wysyła robota na kolejne punkty patrolowe.\n2. Kliknięcie **Jedź do celu** ustawia `DemoMode.GOAL`, anuluje ewentualny patrol i uruchamia priorytetową nawigację do `GOAL_POSE`.\n3. Po wyniku `TaskResult.SUCCEEDED` cel jest czyszczony, a tryb wraca do `DemoMode.PATROL`, więc robot automatycznie kontynuuje patrol.\n4. Kliknięcie **Stop** ustawia `DemoMode.STOPPED`, anuluje aktywne zadanie Nav2 i publikuje zerowe `/cmd_vel`.\n\nPodczas patrolu lub jazdy do celu robot powinien publikować niezerowe komendy prędkości:\n\n```bash\nros2 topic echo --once /cmd_vel\n```\n\nPo kilku sekundach powinny zmieniać się współrzędne odometrii:\n\n```bash\nros2 topic echo --once /odom\n```\n\nSamodzielny test skryptu można uruchomić po starcie Gazebo i Nav2:\n\n```bash\npython3 trees_nav.py --auto-test\n```\n\nTest wykonany w kontenerze `ros_fun` na obrazie `ros_fun:native` 2026-06-13 potwierdził scenariusz fallbacku: robot rozpoczął patrol, po żądaniu **Jedź do celu** dojechał do celu `(0.50, -1.20)`, dostał `TaskResult.SUCCEEDED`, wyczyścił cel i sam wrócił do patrolu na kolejny punkt `(2.53, 0.99)`. W ostatnim przebiegu skryptu `trees_nav.py --auto-test` zapisano 2110 próbek `/odom`, 1680 próbek `/cmd_vel`, 1548 niezerowych komend, około 5.45 m drogi i końcowe `/cmd_vel == (0.0, 0.0)`.\n\nDodatkowo uruchomienie komórek notebooka z tym samym runnerem potwierdziło render kontrolek: przyciski `ipywidgets` zwróciły MIME `application/vnd.jupyter.widget-view+json`, a fallback HTML zawierał **Jedź do celu**, **Stop** i **Wyczyść cel / patrol**. W tym przebiegu robot przejechał około 2.78 m, `/cmd_vel` miał 641 próbek, 589 niezerowych, a po `stop_robot()` ostatnia komenda była zerowa.\n\nPo zakończeniu demo uruchom ostatnią komórkę. Zatrzyma wątek drzewa, anuluje aktywne zadanie Nav2 i posprząta procesy warsztatowe.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e988f055",
+   "metadata": {},
+   "outputs": [],
+   "source": "try:\n    runner.stop(cancel=navigator.cancelTask)\nexcept NameError:\n    pass\n\ntry:\n    navigator.cancelTask()\nexcept Exception:\n    pass\n\ntry:\n    demo_node.destroy_node()\nexcept Exception:\n    pass\n\nhelper_services.cleanup_workshop_processes()\nrclpy.try_shutdown()\nprint(\"Demo zatrzymane.\")\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter_notebooks/exercises/trees_nav.py
+++ b/jupyter_notebooks/exercises/trees_nav.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""Behavior Trees + Nav2 helper demo.
+
+Run this after Gazebo and Nav2 are active:
+
+    python3 trees_nav.py --auto-test
+
+The same module is imported by the notebook so the exercise and the standalone
+test use one implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+import py_trees
+import rclpy
+from geometry_msgs.msg import PoseStamped, TwistStamped
+from nav_msgs.msg import Odometry
+from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+
+PATROL_WAYPOINTS = [
+    (0.45, 1.91, 0.0),
+    (2.53, 0.99, -1.57),
+    (1.72, -1.37, 3.14),
+    (-0.25, -1.15, 1.57),
+]
+
+GOAL_POSE = (0.50, -1.20, 0.0)
+
+
+class DemoMode(Enum):
+    PATROL = "patrol"
+    GOAL = "goal"
+    STOPPED = "stopped"
+
+
+@dataclass
+class DemoState:
+    mode: DemoMode = DemoMode.PATROL
+    status: str = "Patrol wokół zamku"
+    patrol_cycles: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    events: list[dict] = field(default_factory=list)
+
+    def set_mode(self, mode: DemoMode, status: str, event: str | None = None, **data):
+        with self.lock:
+            self.mode = mode
+            self.status = status
+            if event:
+                self.events.append(
+                    {
+                        "time": time.time(),
+                        "event": event,
+                        "mode": mode.value,
+                        "status": status,
+                        "data": data,
+                    }
+                )
+
+    def snapshot(self):
+        with self.lock:
+            return self.mode, self.status, self.patrol_cycles
+
+    def add_patrol_cycle(self):
+        with self.lock:
+            self.patrol_cycles += 1
+            self.status = f"Cykl patrolu {self.patrol_cycles} zakończony; kontynuuję patrol"
+            self.events.append(
+                {
+                    "time": time.time(),
+                    "event": "patrol_cycle",
+                    "mode": self.mode.value,
+                    "status": self.status,
+                    "data": {"cycles": self.patrol_cycles},
+                }
+            )
+
+    def event_log(self) -> list[dict]:
+        with self.lock:
+            return list(self.events)
+
+
+class DemoNode(Node):
+    def __init__(self, name="castle_bt_demo_helper"):
+        super().__init__(
+            name,
+            parameter_overrides=[Parameter("use_sim_time", value=True)],
+        )
+
+
+@dataclass
+class DemoContext:
+    node: Node
+    navigator: BasicNavigator
+    state: DemoState
+    waypoints: list[tuple[float, float, float]]
+    goal: tuple[float, float, float]
+    cmd_vel_publisher: object | None = None
+
+    def yaw_to_quaternion(self, yaw: float) -> tuple[float, float]:
+        return math.sin(yaw / 2.0), math.cos(yaw / 2.0)
+
+    def make_pose(self, x: float, y: float, yaw: float) -> PoseStamped:
+        pose = PoseStamped()
+        pose.header.frame_id = "map"
+        pose.header.stamp = self.navigator.get_clock().now().to_msg()
+        pose.pose.position.x = float(x)
+        pose.pose.position.y = float(y)
+        pose.pose.position.z = 0.0
+        pose.pose.orientation.z, pose.pose.orientation.w = self.yaw_to_quaternion(float(yaw))
+        return pose
+
+    def goal_pose(self) -> PoseStamped:
+        return self.make_pose(*self.goal)
+
+    def request_goal(self) -> str:
+        self.state.set_mode(DemoMode.GOAL, "Kliknięto: jedź do celu", "button_goal")
+        return status_text(self.state)
+
+    def request_stop(self) -> str:
+        self.state.set_mode(DemoMode.STOPPED, "Kliknięto: stop", "button_stop")
+        self.navigator.cancelTask()
+        self.publish_stop()
+        return status_text(self.state)
+
+    def request_patrol(self) -> str:
+        self.navigator.cancelTask()
+        self.publish_stop()
+        self.state.set_mode(
+            DemoMode.PATROL,
+            "Cel wyczyszczony; patrol jako fallback",
+            "button_patrol",
+        )
+        return status_text(self.state)
+
+    def publish_stop(self, repeats: int = 5):
+        if self.cmd_vel_publisher is None:
+            return
+        msg = TwistStamped()
+        msg.header.stamp = self.node.get_clock().now().to_msg()
+        msg.header.frame_id = "base_link"
+        for _ in range(repeats):
+            msg.header.stamp = self.node.get_clock().now().to_msg()
+            self.cmd_vel_publisher.publish(msg)
+            time.sleep(0.03)
+
+
+def status_text(state: DemoState) -> str:
+    mode, message, cycles = state.snapshot()
+    return f"Tryb: {mode.value} | Cykle patrolu: {cycles} | Status: {message}"
+
+
+class ModeIs(py_trees.behaviour.Behaviour):
+    def __init__(self, context: DemoContext, name: str, expected_mode: DemoMode):
+        super().__init__(name=name)
+        self.context = context
+        self.expected_mode = expected_mode
+
+    def update(self):
+        mode, status, _ = self.context.state.snapshot()
+        self.feedback_message = status
+        if mode == self.expected_mode:
+            return py_trees.common.Status.SUCCESS
+        return py_trees.common.Status.FAILURE
+
+
+class CancelNavigation(py_trees.behaviour.Behaviour):
+    def __init__(self, context: DemoContext, name="Anuluj nawigację"):
+        super().__init__(name=name)
+        self.context = context
+
+    def initialise(self):
+        self.context.navigator.cancelTask()
+        self.context.publish_stop()
+        self.context.state.set_mode(
+            DemoMode.STOPPED,
+            "Nawigacja anulowana; robot zatrzymany",
+            "cancel_initialise",
+        )
+
+    def update(self):
+        self.feedback_message = "Zażądano stopu"
+        return py_trees.common.Status.RUNNING
+
+
+class NavigateToGoal(py_trees.behaviour.Behaviour):
+    def __init__(self, context: DemoContext, name="Jedź do celu"):
+        super().__init__(name=name)
+        self.context = context
+        self.goal_sent = False
+
+    def initialise(self):
+        self.context.navigator.cancelTask()
+        time.sleep(0.2)
+        self.context.navigator.goToPose(self.context.goal_pose())
+        self.goal_sent = True
+        x, y, _ = self.context.goal
+        self.context.state.set_mode(
+            DemoMode.GOAL,
+            f"Jadę do celu ({x:.2f}, {y:.2f})",
+            "goal_sent",
+            x=x,
+            y=y,
+        )
+
+    def update(self):
+        mode, _, _ = self.context.state.snapshot()
+        if mode == DemoMode.STOPPED:
+            self.context.navigator.cancelTask()
+            self.context.publish_stop()
+            return py_trees.common.Status.FAILURE
+
+        if not self.goal_sent or not self.context.navigator.isTaskComplete():
+            feedback = self.context.navigator.getFeedback()
+            if feedback is not None:
+                remaining = getattr(feedback, "estimated_time_remaining", None)
+                if remaining is not None:
+                    seconds = remaining.sec + remaining.nanosec / 1e9
+                    self.feedback_message = f"cel aktywny, około {seconds:.0f} s do końca"
+            return py_trees.common.Status.RUNNING
+
+        result = self.context.navigator.getResult()
+        self.goal_sent = False
+        self.context.state.set_mode(
+            self.context.state.snapshot()[0],
+            f"Wynik celu: {result}",
+            "goal_result",
+            result=str(result),
+        )
+        if result == TaskResult.SUCCEEDED:
+            self.context.state.set_mode(
+                DemoMode.PATROL,
+                "Cel osiągnięty; wracam do patrolu",
+                "goal_cleared_to_patrol",
+            )
+            self.feedback_message = "cel osiągnięty, patrol jako fallback"
+            return py_trees.common.Status.SUCCESS
+        if result == TaskResult.CANCELED:
+            self.context.state.set_mode(
+                DemoMode.PATROL,
+                "Cel anulowany; wracam do patrolu",
+                "goal_canceled_to_patrol",
+            )
+            self.feedback_message = "cel anulowany, wracam do patrolu"
+            return py_trees.common.Status.FAILURE
+        self.context.state.set_mode(
+            DemoMode.STOPPED,
+            "Cel nieudany; robot zatrzymany",
+            "goal_failed",
+            result=str(result),
+        )
+        self.feedback_message = "cel nieudany"
+        return py_trees.common.Status.FAILURE
+
+    def terminate(self, new_status):
+        mode, _, _ = self.context.state.snapshot()
+        if new_status == py_trees.common.Status.INVALID and self.goal_sent and mode == DemoMode.GOAL:
+            self.context.navigator.cancelTask()
+            self.goal_sent = False
+
+
+class PatrolCastle(py_trees.behaviour.Behaviour):
+    def __init__(self, context: DemoContext, name="Patrol zamku"):
+        super().__init__(name=name)
+        self.context = context
+        self.goal_sent = False
+        self.waypoint_index = 0
+
+    def send_next_waypoint(self):
+        x, y, yaw = self.context.waypoints[self.waypoint_index]
+        self.context.navigator.goToPose(self.context.make_pose(x, y, yaw))
+        self.goal_sent = True
+        self.context.state.set_mode(
+            DemoMode.PATROL,
+            f"Patrol: punkt {self.waypoint_index + 1}/{len(self.context.waypoints)}",
+            "patrol_goal_sent",
+            waypoint=self.waypoint_index + 1,
+            x=x,
+            y=y,
+        )
+
+    def initialise(self):
+        if not self.goal_sent:
+            self.send_next_waypoint()
+
+    def update(self):
+        mode, _, cycles = self.context.state.snapshot()
+        if mode != DemoMode.PATROL:
+            self.context.navigator.cancelTask()
+            self.goal_sent = False
+            return py_trees.common.Status.FAILURE
+
+        if not self.goal_sent or not self.context.navigator.isTaskComplete():
+            feedback = self.context.navigator.getFeedback()
+            if feedback is not None:
+                remaining = getattr(feedback, "estimated_time_remaining", None)
+                if remaining is not None:
+                    seconds = remaining.sec + remaining.nanosec / 1e9
+                    self.feedback_message = (
+                        f"cykl {cycles}, punkt {self.waypoint_index + 1}, "
+                        f"około {seconds:.0f} s do końca"
+                    )
+            return py_trees.common.Status.RUNNING
+
+        result = self.context.navigator.getResult()
+        self.goal_sent = False
+        if result == TaskResult.SUCCEEDED:
+            self.waypoint_index = (self.waypoint_index + 1) % len(self.context.waypoints)
+            if self.waypoint_index == 0:
+                self.context.state.add_patrol_cycle()
+            self.send_next_waypoint()
+            return py_trees.common.Status.RUNNING
+        if result == TaskResult.CANCELED:
+            self.feedback_message = "patrol anulowany"
+            return py_trees.common.Status.FAILURE
+        self.feedback_message = "patrol nieudany; czyszczę costmapy i spróbuję ponownie"
+        self.context.navigator.clearAllCostmaps()
+        return py_trees.common.Status.FAILURE
+
+    def terminate(self, new_status):
+        mode, _, _ = self.context.state.snapshot()
+        if new_status == py_trees.common.Status.INVALID and self.goal_sent and mode == DemoMode.PATROL:
+            self.context.navigator.cancelTask()
+            self.goal_sent = False
+
+
+def make_tree(context: DemoContext) -> py_trees.trees.BehaviourTree:
+    root = py_trees.composites.Selector(name="Castle Demo", memory=False)
+
+    stopped = py_trees.composites.Sequence(name="STOPPED?", memory=True)
+    stopped.add_children(
+        [ModeIs(context, "tryb STOPPED?", DemoMode.STOPPED), CancelNavigation(context)]
+    )
+
+    goal = py_trees.composites.Sequence(name="GOAL?", memory=True)
+    goal.add_children([ModeIs(context, "tryb GOAL?", DemoMode.GOAL), NavigateToGoal(context)])
+
+    patrol = py_trees.composites.Sequence(name="PATROL fallback", memory=True)
+    patrol.add_children([ModeIs(context, "tryb PATROL?", DemoMode.PATROL), PatrolCastle(context)])
+
+    root.add_children([stopped, goal, patrol])
+    return py_trees.trees.BehaviourTree(root)
+
+
+class TreeRunner:
+    def __init__(self, tree: py_trees.trees.BehaviourTree, period=0.5, on_tick=None):
+        self.tree = tree
+        self.period = period
+        self.on_tick = on_tick
+        self.running = False
+        self.thread: threading.Thread | None = None
+        self.last_error: BaseException | None = None
+
+    def start(self):
+        if self.running:
+            print("Wątek drzewa już działa")
+            return
+        self.running = True
+        self.last_error = None
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+        print("Wątek drzewa uruchomiony")
+
+    def stop(self, cancel=None):
+        self.running = False
+        if self.thread is not None:
+            self.thread.join(timeout=2.0)
+        if cancel is not None:
+            cancel()
+        print("Wątek drzewa zatrzymany")
+
+    def _run(self):
+        while self.running:
+            try:
+                self.tree.tick()
+                if self.on_tick is not None:
+                    self.on_tick(self.tree)
+                time.sleep(self.period)
+            except Exception as exc:  # pragma: no cover - printed for notebook users
+                self.last_error = exc
+                self.running = False
+                print("Błąd wątku drzewa:", repr(exc))
+                traceback.print_exc()
+
+
+class MotionMonitor(Node):
+    def __init__(self):
+        super().__init__("castle_bt_motion_monitor")
+        self.odom_samples = 0
+        self.cmd_samples = 0
+        self.nonzero_cmd_samples = 0
+        self.first_pose = None
+        self.last_pose = None
+        self.path_points = []
+        self.path_length = 0.0
+        self.last_cmd = None
+        self.create_subscription(Odometry, "/odom", self._odom_callback, 10)
+        self.create_subscription(TwistStamped, "/cmd_vel", self._cmd_stamped_callback, 10)
+
+    def _odom_callback(self, msg):
+        pose = msg.pose.pose.position
+        point = (float(pose.x), float(pose.y))
+        if self.first_pose is None:
+            self.first_pose = point
+        if self.last_pose is not None:
+            self.path_length += math.hypot(point[0] - self.last_pose[0], point[1] - self.last_pose[1])
+        self.last_pose = point
+        if not self.path_points or math.hypot(point[0] - self.path_points[-1][0], point[1] - self.path_points[-1][1]) >= 0.02:
+            self.path_points.append(point)
+        self.odom_samples += 1
+
+    def _cmd_stamped_callback(self, msg):
+        self._record_cmd(msg.twist.linear.x, msg.twist.angular.z)
+
+    def _record_cmd(self, linear_x, angular_z):
+        self.cmd_samples += 1
+        self.last_cmd = (float(linear_x), float(angular_z))
+        if abs(linear_x) > 1e-4 or abs(angular_z) > 1e-4:
+            self.nonzero_cmd_samples += 1
+
+    def summary(self):
+        return {
+            "odom_samples": self.odom_samples,
+            "cmd_samples": self.cmd_samples,
+            "nonzero_cmd_samples": self.nonzero_cmd_samples,
+            "first_pose": self.first_pose,
+            "last_pose": self.last_pose,
+            "path_length_m": round(self.path_length, 3),
+            "path_points": len(self.path_points),
+            "last_cmd": self.last_cmd,
+        }
+
+
+def draw_path_png(
+    output_path: str | Path,
+    path_points: list[tuple[float, float]],
+    map_yaml="/home/ubuntu/turtlebot3_ws/src/jupyter_notebooks/map.yaml",
+    waypoints=PATROL_WAYPOINTS,
+    goal=GOAL_POSE,
+    scale=4,
+):
+    from PIL import Image, ImageDraw
+
+    metadata = {}
+    for raw_line in Path(map_yaml).read_text().splitlines():
+        if ":" not in raw_line:
+            continue
+        key, value = raw_line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+
+    image_path = metadata["image"]
+    resolution = float(metadata.get("resolution", "0.05"))
+    origin_text = metadata.get("origin", "[0, 0, 0]").strip("[]")
+    origin_x, origin_y, _ = [float(part.strip()) for part in origin_text.split(",")]
+
+    image = Image.open(image_path).convert("RGB")
+    draw = ImageDraw.Draw(image)
+    width, height = image.size
+
+    def to_pixel(point):
+        x, y = point[:2]
+        px = int(round((x - origin_x) / resolution))
+        py = int(round(height - (y - origin_y) / resolution))
+        return px, py
+
+    for x, y, _ in waypoints:
+        px, py = to_pixel((x, y))
+        draw.ellipse((px - 4, py - 4, px + 4, py + 4), fill=(255, 165, 0), outline=(80, 50, 0))
+
+    gx, gy, _ = goal
+    gpx, gpy = to_pixel((gx, gy))
+    draw.rectangle((gpx - 5, gpy - 5, gpx + 5, gpy + 5), fill=(128, 0, 180), outline=(40, 0, 60))
+
+    if len(path_points) >= 2:
+        pixels = [to_pixel(point) for point in path_points]
+        draw.line(pixels, fill=(220, 20, 60), width=3)
+        sx, sy = pixels[0]
+        ex, ey = pixels[-1]
+        draw.ellipse((sx - 5, sy - 5, sx + 5, sy + 5), fill=(0, 160, 0), outline=(0, 60, 0))
+        draw.ellipse((ex - 5, ey - 5, ex + 5, ey + 5), fill=(0, 90, 220), outline=(0, 30, 80))
+
+    if scale > 1:
+        image = image.resize((width * int(scale), height * int(scale)), Image.Resampling.NEAREST)
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image.save(output_path)
+    return str(output_path)
+
+
+def setup_navigation(
+    helper_services=None,
+    waypoints: Iterable[tuple[float, float, float]] | None = None,
+    goal: tuple[float, float, float] = GOAL_POSE,
+) -> tuple[DemoNode, DemoContext]:
+    try:
+        rclpy.init()
+    except RuntimeError:
+        pass
+
+    demo_node = DemoNode()
+    if helper_services is not None:
+        helper_services.set_controller_frequency(demo_node)
+        helper_services.publish_initial_pose(demo_node)
+
+    navigator = BasicNavigator()
+    initial_pose = PoseStamped()
+    initial_pose.header.frame_id = "map"
+    initial_pose.header.stamp = navigator.get_clock().now().to_msg()
+    initial_pose.pose.position.x = 0.08
+    initial_pose.pose.position.y = 0.0
+    initial_pose.pose.orientation.w = 1.0
+    navigator.setInitialPose(initial_pose)
+    navigator.waitUntilNav2Active()
+    navigator.clearAllCostmaps()
+
+    context = DemoContext(
+        node=demo_node,
+        navigator=navigator,
+        state=DemoState(),
+        waypoints=list(waypoints or PATROL_WAYPOINTS),
+        goal=goal,
+    )
+    context.cmd_vel_publisher = demo_node.create_publisher(TwistStamped, "/cmd_vel", 10)
+    context.state.set_mode(DemoMode.PATROL, "Patrol wokół zamku", "tree_started")
+    return demo_node, context
+
+
+def run_auto_test(args) -> int:
+    import helper_services
+
+    demo_node, context = setup_navigation(helper_services)
+    tree = make_tree(context)
+    tree.setup(timeout=15)
+    monitor = MotionMonitor()
+    monitor_executor = SingleThreadedExecutor()
+    monitor_executor.add_node(monitor)
+    monitor_running = True
+
+    def spin_monitor():
+        while monitor_running:
+            monitor_executor.spin_once(timeout_sec=0.05)
+
+    monitor_thread = threading.Thread(target=spin_monitor, daemon=True)
+    monitor_thread.start()
+    start = time.time()
+    goal_requested = False
+    stop_requested = False
+    fallback_seen = False
+
+    try:
+        while time.time() - start < args.duration:
+            elapsed = time.time() - start
+            tree.tick()
+
+            events = context.state.event_log()
+            fallback_seen = any(e["event"] == "goal_cleared_to_patrol" for e in events) and any(
+                e["event"] == "patrol_goal_sent"
+                and e["time"] > next(
+                    ge["time"] for ge in events if ge["event"] == "goal_cleared_to_patrol"
+                )
+                for e in events
+            )
+
+            if not goal_requested and elapsed >= args.goal_after:
+                print(context.request_goal())
+                goal_requested = True
+
+            if goal_requested and fallback_seen and not stop_requested and elapsed >= args.stop_after:
+                print(context.request_stop())
+                stop_requested = True
+                break
+
+            time.sleep(args.period)
+    finally:
+        context.navigator.cancelTask()
+        context.publish_stop(repeats=10)
+        time.sleep(0.5)
+        monitor_running = False
+        monitor_thread.join(timeout=2.0)
+        monitor_executor.remove_node(monitor)
+        monitor_executor.shutdown()
+        demo_node.destroy_node()
+        monitor.destroy_node()
+        rclpy.try_shutdown()
+
+    summary = {
+        "events": context.state.event_log(),
+        "motion": monitor.summary(),
+        "fallback_patrol_after_goal": fallback_seen,
+        "stop_sent": stop_requested,
+    }
+    if args.output:
+        Path(args.output).write_text(json.dumps(summary, ensure_ascii=False, indent=2))
+    if args.path_png:
+        summary["path_png"] = draw_path_png(args.path_png, monitor.path_points, scale=args.path_scale)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+    moving = summary["motion"]["path_length_m"] >= args.min_path
+    commanded = summary["motion"]["nonzero_cmd_samples"] >= args.min_cmd_samples
+    if fallback_seen and moving and commanded:
+        return 0
+    return 2
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--auto-test", action="store_true", help="run goal/patrol/stop scenario")
+    parser.add_argument("--duration", type=float, default=120.0)
+    parser.add_argument("--goal-after", type=float, default=18.0)
+    parser.add_argument("--stop-after", type=float, default=80.0)
+    parser.add_argument("--period", type=float, default=0.5)
+    parser.add_argument("--min-path", type=float, default=2.0)
+    parser.add_argument("--min-cmd-samples", type=int, default=20)
+    parser.add_argument("--output", default="/tmp/castle_bt_auto_test.json")
+    parser.add_argument("--path-png", default="", help="draw odom path over map image")
+    parser.add_argument("--path-scale", type=int, default=4, help="integer scale for --path-png")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.auto_test:
+        raise SystemExit(run_auto_test(args))
+    print("Uruchom z --auto-test albo importuj moduł w notebooku.")
+
+
+if __name__ == "__main__":
+    main()

--- a/jupyter_notebooks/exercises/trees_nav.py
+++ b/jupyter_notebooks/exercises/trees_nav.py
@@ -341,15 +341,15 @@ class PatrolCastle(py_trees.behaviour.Behaviour):
 def make_tree(context: DemoContext) -> py_trees.trees.BehaviourTree:
     root = py_trees.composites.Selector(name="Castle Demo", memory=False)
 
-    stopped = py_trees.composites.Sequence(name="STOPPED?", memory=True)
+    stopped = py_trees.composites.Sequence(name="STOPPED?", memory=False)
     stopped.add_children(
         [ModeIs(context, "tryb STOPPED?", DemoMode.STOPPED), CancelNavigation(context)]
     )
 
-    goal = py_trees.composites.Sequence(name="GOAL?", memory=True)
+    goal = py_trees.composites.Sequence(name="GOAL?", memory=False)
     goal.add_children([ModeIs(context, "tryb GOAL?", DemoMode.GOAL), NavigateToGoal(context)])
 
-    patrol = py_trees.composites.Sequence(name="PATROL fallback", memory=True)
+    patrol = py_trees.composites.Sequence(name="PATROL fallback", memory=False)
     patrol.add_children([ModeIs(context, "tryb PATROL?", DemoMode.PATROL), PatrolCastle(context)])
 
     root.add_children([stopped, goal, patrol])


### PR DESCRIPTION
## What changed

- Added a Behavior Trees + Nav2 helper demo notebook for the castle patrol scenario.
- Added `trees_nav.py` as the shared standalone implementation and auto-test entrypoint used by the notebook.
- Updated the Dockerfile so classic Jupyter Notebook has the widget frontend assets enabled reliably.

## Why

The notebook previously could fail in the background tree thread when patrol waypoints were not defined in the active kernel state, and widget buttons were unreliable in the browser. The demo now has one source of truth for the behavior tree, a standalone test path, HTML fallback controls, and explicit stop handling that publishes zero `/cmd_vel`.

## Validation

- `python3 -m py_compile jupyter_notebooks/exercises/trees_nav.py`
- Local notebook JSON and Python-cell AST validation
- Container validation: `py_compile` for `trees_nav.py` and `nbformat.validate(...)`
- Runtime ROS test in `ros_fun:native`: `trees_nav.py --auto-test` confirmed patrol, goal, return to patrol, stop, odometry movement, and final zero `/cmd_vel`
- Notebook-cell execution test confirmed widget MIME output, HTML fallback controls, runner without `last_error`, robot motion, and stop behavior
- Visual path test: `trees_nav.py --auto-test --path-png /tmp/castle_path.png` generated an odometry path image over the map
